### PR TITLE
Add MaxAckPending Arg

### DIFF
--- a/server/conf/conf.go
+++ b/server/conf/conf.go
@@ -172,7 +172,7 @@ type JetStreamConfig struct {
 	EnableFlowControl      bool
 	EnableAckSync          bool
 	HeartbeatInterval      int // milliseconds
-	MaxAckPending					 int
+	MaxAckPending          int
 }
 
 // DefaultBridgeConfig generates a default configuration with

--- a/server/conf/conf.go
+++ b/server/conf/conf.go
@@ -172,6 +172,7 @@ type JetStreamConfig struct {
 	EnableFlowControl      bool
 	EnableAckSync          bool
 	HeartbeatInterval      int // milliseconds
+	MaxAckPending					 int
 }
 
 // DefaultBridgeConfig generates a default configuration with

--- a/server/core/connector.go
+++ b/server/core/connector.go
@@ -386,6 +386,11 @@ func (conn *BridgeConnector) subscribeToJetStream(subject string, queueName stri
 		options = append(options, nats.BindStream(conn.config.Stream))
 	}
 
+	if conn.bridge.config.JetStream.MaxAckPending > 0 {
+		conn.bridge.Logger().Noticef("Setting MaxAckPending=%d", conn.bridge.config.JetStream.MaxAckPending)
+		options = append(options, nats.MaxAckPending(conn.bridge.config.JetStream.MaxAckPending))
+	}
+
 	traceEnabled := conn.bridge.Logger().TraceEnabled()
 	ackSyncEnabled := conn.bridge.config.JetStream.EnableAckSync
 


### PR DESCRIPTION
## Summary
Adds a `MaxAckPending` arg to the JetStreamConfig. This should allow us to increase the num of MaxAckPending from 1000 to a higher number to ideally get the throughput we want out of the nats-kafka-bridge

## Test Plan
1. Ran `makebuild` to build the actual project
2. Modified `conf/jetstream-kafka.conf` to be 
```
nats: {
  Servers: ["nats://nats-url:4222"],
  usercredentials: "{path}/credentials.txt"
}

jetstream: {
  maxwait: 5000,
  maxackpending: 91234
}

connect: [
  {
      type: "JetStreamToKafka",
      brokers: ["localhost:9092"]
      id: "TELEMETRY",
      topic: "telemetry",
      subject: "TELEMETRY.>",
  },
]
```
3. Created a kafka instance in docker
4. Created teh telemetry topic in kafka
5. Then ran `./nats-kafka -c /nats-kafka/conf/jetstream-kafka.conf`